### PR TITLE
Fix: logging fails when message contains non ASCII characters

### DIFF
--- a/config/logging.conf
+++ b/config/logging.conf
@@ -20,7 +20,7 @@ args=(sys.stdout,)
 class=FileHandler
 level=DEBUG
 formatter=file
-args=('logs/bot.log',)
+args=('logs/bot.log', 'a', 'utf-8')
 
 
 


### PR DESCRIPTION
This is damn hard to find ....

'a' is append, I have to include that in argument for that UTF-8 parameter