### PR TITLE
Fix incorrect usage of is

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -236,7 +236,7 @@ class TwitchBot():
 
         If no game is active only allow 'passive games' a.k.a PyramidGame
         """
-        if perm is 0:
+        if perm == 0:
             if (time.time() - self.last_plebcmd < self.pleb_cooldowntime):
                 if self.gameRunning:
                     return self.games
@@ -286,7 +286,7 @@ class TwitchBot():
                     reply = "{}: You don't have access to that command. Minimum level is {}."
                     self.write(reply.format(user, perm_levels[cmd.perm]))
                 else:
-                    if (perm is 0 and cmd not in self.games):   # Only reset plebtimer if no game was played
+                    if (perm == 0 and cmd not in self.games):   # Only reset plebtimer if no game was played
                         self.last_plebcmd = time.time()
                     cmd.run(self, user, msg)
             except (ValueError, TypeError):  # Not sure which Errors might happen here.

--- a/bot/commands.py
+++ b/bot/commands.py
@@ -1169,7 +1169,7 @@ class Notifications(Command):
             self.notifications = json.load(file)
 
         """If notifications are enabled by default, start the threading."""
-        if self.active is True:
+        if self.active:
             self.callID = reactor.callLater(bot.NOTIFICATION_INTERVAL, self.writeNotification, bot)
 
     def raiselistindex(self):
@@ -1190,7 +1190,7 @@ class Notifications(Command):
             return
 
         """Only write notifications if the bot is unpaused."""
-        if bot.pause is not True:
+        if not bot.pause:
             bot.write(self.notifications[self.listindex])
             self.raiselistindex()
 
@@ -1456,7 +1456,7 @@ class Speech(Command):
 
     def run(self, bot, user, msg):
         """Send message to cleverbot only if no other command got triggered."""
-        if bot.antispeech is not True:
+        if not bot.antispeech:
             msg = msg.lower()
             msg = msg.replace("@", '')
             msg = msg.replace(bot.nickname, '')
@@ -1618,7 +1618,7 @@ class MonkalotParty(Command):
 
     def selectGame(self, bot):
         """Select a game to play next."""
-        if self.active is False:
+        if not self.active:
             return
 
         game = random.choice(list(self.mp.games))
@@ -1770,8 +1770,7 @@ class UserIgnore(Command):
             ignoreReply = self.responses["ignore"]
             # bot can ignore ANYONE, we just add the name to bot.ignored_users
             # IMPORTNT: ANYONE includes owner, mod and the bot itself, we do the checking here to prevent it
-
-            if (target in bot.owner_list + bot.trusted_mods) or (target is bot.nickname):
+            if (target == bot.nickname) or any(target in coll for coll in (bot.owner_list, bot.trusted_mods)):
                 reply = ignoreReply["privileged"]
             elif (target in bot.ignored_users):
                 # already ignored

--- a/bot/ranking.py
+++ b/bot/ranking.py
@@ -71,7 +71,7 @@ class Ranking():
         self.executeCommand(sql_command, [points, username])
 
         """Check for legend rank if user was not legend before."""
-        if legend is False:
+        if not legend:
             rank = self.getHSRank(points)
             if "Legend" in rank:
                 var = {"<USER>": bot.displayName(username), "<RANK>": rank}


### PR DESCRIPTION
git grep " is "

"is" in Python is used to check for refering to same object or not

True is True; False is False would work
But "0 is False" and "0 == False" are different

If we want to check True/False value, just use "if not var:" or "if
var:"

"is number" won't work if the number is too large/small for python to
cache (larger than 256 seems won't cache)

k = 999
k is 999 #False unless we try sys.intern stuff

Reference: https://stackoverflow.com/question/4050335/